### PR TITLE
Removed non-supported log2 override that caused msvc build errors

### DIFF
--- a/include/stxxl/bits/msvc_compatibility.h
+++ b/include/stxxl/bits/msvc_compatibility.h
@@ -19,11 +19,6 @@
 
 #include <cmath>
 
-inline double log2(double x)
-{
-    return (log(x) / log(2.));
-}
-
 // http://msdn.microsoft.com/en-us/library/2ts7cx93.aspx
 #define snprintf _snprintf
 


### PR DESCRIPTION
The log2 method does not compile on msvc 2022 (and throws a warning on 2019)