### PR TITLE
Remove log in singleton destructor

### DIFF
--- a/lib/mng/config.cpp
+++ b/lib/mng/config.cpp
@@ -46,7 +46,6 @@ config::~config()
     {
         if (it->delete_on_exit)
         {
-            STXXL_ERRMSG("Removing disk file: " << it->path);
             unlink(it->path.c_str());
         }
     }


### PR DESCRIPTION
This was causing a segfault on exit. The reason is that the logger (another singleton) had already been destroyed. The singletons are destroyed on exit using std::atexit, which is used to register them on first call to get_instance(). They are then called in reverse order. This means the logger has to be the first registered singleton to be destroyed last, but is registered only at the first log message. This means there is no robust guarantee that the logger is available in the destructors of the other singletons, and should thus not be used there